### PR TITLE
Revert to LDFLAGS passed compile params 

### DIFF
--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -16,7 +16,7 @@ builds:
     gobinary: garble
     hooks:
       pre: 
-      - go get github.com/lmvlmv/garble@v0.2.0-tiny.2
+      - go get github.com/lmvlmv/garble@v0.2.0-random.0
 archives:
   - format: gz
     files:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/jpillora/requestlog v1.0.0
 	github.com/jpillora/sizestr v1.0.0
-	github.com/lmvlmv/garble v0.2.0-tiny.2 // indirect
+	github.com/lmvlmv/garble v0.2.0-random.0 // indirect
 	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce // indirect
 	golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f // CVE-2020-29652
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/jpillora/sizestr v1.0.0/go.mod h1:bUhLv4ctkknatr6gR42qPxirmd5+ds1u7mz
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lmvlmv/garble v0.2.0-random.0 h1:1ROH1l1OyWI+peAQIoJXGfmfNJwLm5t86llEwVS5MLM=
+github.com/lmvlmv/garble v0.2.0-random.0/go.mod h1:0YShESH3bykTK9E75wr7A/UYTHIi/ziAyV8OGZ/rlwo=
 github.com/lmvlmv/garble v0.2.0-tiny.2 h1:Nb/qhxF3Xoj0LbIu+zugSC4MSaU6BhYlIUAIIY8V//U=
 github.com/lmvlmv/garble v0.2.0-tiny.2/go.mod h1:0YShESH3bykTK9E75wr7A/UYTHIi/ziAyV8OGZ/rlwo=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/main.go
+++ b/main.go
@@ -21,8 +21,8 @@ import (
 var help = `
   Usage: chisel [command] [--help]
 
-  Version: 1.7.6-rte.1
-
+  Version: ` + chshare.BuildVersion + ` (` + runtime.Version() + `)
+  
   Commands:
     server - runs chisel in server mode
     client - runs chisel in client mode


### PR DESCRIPTION
Uses garble without -tiny and random seed by default